### PR TITLE
PVS-21: Add TraceLayer request/response logging with latency and log level config.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1702,6 +1702,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/api-gateway/Cargo.toml
+++ b/crates/api-gateway/Cargo.toml
@@ -14,7 +14,7 @@ serde_json = "1.0.142"
 thiserror = "2.0.15"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tower = { version = "0.5", features = ["timeout"] }
-tower-http = { version = "0.6.6", features = ["cors", "timeout"] }
+tower-http = { version = "0.6.6", features = ["cors", "timeout", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1.18.0", features = ["v4"] }

--- a/crates/api-gateway/src/lib.rs
+++ b/crates/api-gateway/src/lib.rs
@@ -21,6 +21,9 @@ pub async fn request_id_middleware(mut request: Request, next: Next) -> Response
     // Store in request extensions for downstream access
     request.extensions_mut().insert(request_id.clone());
 
+    // Add request_id to the current tracing span for trace middleware
+    tracing::Span::current().record("request_id", &request_id);
+
     // Log the request ID for tracing
     tracing::info!("Processing request with ID: {}", request_id);
 


### PR DESCRIPTION
Acceptance criteria

    Every request logs method, path, status, latency.

    Log level configurable via RUST_LOG/env (e.g., info, debug).

    Errors log stack/context.

Tasks

    Add tower_http::trace::TraceLayer with custom on_request/on_response/on_failure.

    Include request_id (from PVS-22) in all logs.